### PR TITLE
v8 opt: Copy arguments into new array rather than use [].slice

### DIFF
--- a/src/Factory.js
+++ b/src/Factory.js
@@ -60,7 +60,8 @@ oo.Factory.prototype.register = function ( constructor ) {
  * @throws {Error} Unknown object name
  */
 oo.Factory.prototype.create = function ( name ) {
-	var args, obj,
+	var obj, i,
+		args = [],
 		constructor = this.lookup( name );
 
 	if ( !constructor ) {
@@ -68,7 +69,9 @@ oo.Factory.prototype.create = function ( name ) {
 	}
 
 	// Convert arguments to array and shift the first argument (name) off
-	args = Array.prototype.slice.call( arguments, 1 );
+	for ( i = 1; i < arguments.length; i++ ) {
+		args.push( arguments[i] );
+	}
 
 	// We can't use the "new" operator with .apply directly because apply needs a
 	// context. So instead just do what "new" does: create an object that inherits from


### PR DESCRIPTION
Calling Array.prototype.slice on the arguments object disables certain V8
optimizations. The Chrome Dev Tools profiler flags OO.Factory with the warning
"bad value context for arguments value". Using a simple array copy is just as
idiomatic and ought to work faster.

I didn't see a statistically significant improvement from this change, but I
plan on submitting these as I go down the list of warnings if the change needed
to make v8 happy doesn't compromise the readability of the code.

Some more details here: https://github.com/jashkenas/coffeescript/issues/3274
